### PR TITLE
Add unionOfLiterals codec factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ This is just a very basic example. In your case, you may want to additionally en
 - Values deeply nested in your application state: `root.nested(property)`
 - ISO 8601 dates: `@lobelia-earth/url-state-codecs/iso8601Date`
 - Booleans: `@lobelia-earth/url-state-codecs/boolean`
+- Unions of literal values: `@lobelia-earth/url-state-codecs/unionOfLiterals` (a factory function that creates a codec from array of literal values)
 - Entire objects as base 64 strings: `@lobelia-earth/url-state-codecs/base64Json`
 - `NaN` (since `NaN` is disallowed by the number codec by default): `@lobelia-earth/url-state-codecs/wrappers/withNaN`
 - Any of the above as a nullable value:`@lobelia-earth/url-state-codecs/wrappers/nullable`

--- a/esbuild.js
+++ b/esbuild.js
@@ -16,6 +16,7 @@ const extensionlessPaths = [
   'codecs/iso8601DateCodec',
   'codecs/numberCodec',
   'codecs/stringCodec',
+  'codecs/unionOfLiterals',
   'codecs/wrappers/arrayOf',
   'codecs/wrappers/nullable',
   'codecs/wrappers/withDeflateRaw',

--- a/esbuild.metafile.json
+++ b/esbuild.metafile.json
@@ -147,6 +147,32 @@
       ],
       "format": "esm"
     },
+    "src/codecs/unionOfLiterals.ts": {
+      "bytes": 3461,
+      "imports": [
+        {
+          "path": "../lib/types",
+          "kind": "import-statement",
+          "external": true
+        },
+        {
+          "path": "src/lib/result.ts",
+          "kind": "import-statement",
+          "original": "../lib/result"
+        },
+        {
+          "path": "src/codecs/stringCodec.ts",
+          "kind": "import-statement",
+          "original": "./stringCodec"
+        },
+        {
+          "path": "src/codecs/numberCodec.ts",
+          "kind": "import-statement",
+          "original": "./numberCodec"
+        }
+      ],
+      "format": "esm"
+    },
     "src/codecs/wrappers/arrayOf.ts": {
       "bytes": 4751,
       "imports": [
@@ -474,6 +500,34 @@
         }
       },
       "bytes": 432
+    },
+    "dist/codecs/unionOfLiterals.js.map": {
+      "imports": [],
+      "exports": [],
+      "inputs": {},
+      "bytes": 10900
+    },
+    "dist/codecs/unionOfLiterals.js": {
+      "imports": [],
+      "exports": [
+        "default"
+      ],
+      "entryPoint": "src/codecs/unionOfLiterals.ts",
+      "inputs": {
+        "src/lib/result.ts": {
+          "bytesInOutput": 49
+        },
+        "src/codecs/stringCodec.ts": {
+          "bytesInOutput": 321
+        },
+        "src/codecs/numberCodec.ts": {
+          "bytesInOutput": 595
+        },
+        "src/codecs/unionOfLiterals.ts": {
+          "bytesInOutput": 1069
+        }
+      },
+      "bytes": 2100
     },
     "dist/codecs/wrappers/arrayOf.js.map": {
       "imports": [],

--- a/esbuild.metafile.txt
+++ b/esbuild.metafile.txt
@@ -33,6 +33,13 @@
    └ src/lib/result.ts           49b    11.3%
 
 
+  dist/codecs/unionOfLiterals.js    2.1kb  100.0%
+   ├ src/codecs/unionOfLiterals.ts  1.0kb   50.9%
+   ├ src/codecs/numberCodec.ts      595b    28.3%
+   ├ src/codecs/stringCodec.ts      321b    15.3%
+   └ src/lib/result.ts               49b     2.3%
+
+
   dist/codecs/wrappers/arrayOf.js    1.2kb  100.0%
    ├ src/codecs/wrappers/arrayOf.ts  1.1kb   91.1%
    └ src/lib/result.ts                49b     4.1%

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "./iso8601Date": "./dist/codecs/iso8601DateCodec.js",
     "./number": "./dist/codecs/numberCodec.js",
     "./string": "./dist/codecs/stringCodec.js",
+    "./unionOfLiterals": "./dist/codecs/unionOfLiterals.js",
     "./wrappers/arrayOf": "./dist/codecs/wrappers/arrayOf.js",
     "./wrappers/nullable": "./dist/codecs/wrappers/nullable.js",
     "./wrappers/withDeflateRaw": "./dist/codecs/wrappers/withDeflateRaw.js",

--- a/src/codecs/unionOfLiterals.test.ts
+++ b/src/codecs/unionOfLiterals.test.ts
@@ -1,0 +1,45 @@
+import { assert, describe, expect, test } from 'vitest';
+import unionOfLiterals from './unionOfLiterals';
+
+describe('unionOfLiterals', () => {
+  describe('Simple union of strings and numbers', () => {
+    const unionCodec = unionOfLiterals(['a', 'b', 'c', 1, 2, 3]);
+
+    test('Valid value to encode without default', () => {
+      const encodeResult = unionCodec.encode('a');
+      assert(encodeResult.ok);
+      expect(encodeResult.data).toBe('a');
+    });
+
+    test('Invalid value to encode', () => {
+      // @ts-expect-error
+      const encodeResult = unionCodec.encode('d');
+      assert(!encodeResult.ok);
+    });
+
+    test('Valid value to decode', () => {
+      const decodeResult = unionCodec.decode('2');
+      assert(decodeResult.ok);
+      expect(decodeResult.data).toBe(2);
+    });
+
+    test('Value to decode is not a member', () => {
+      const decodeResult = unionCodec.decode('d');
+      assert(!decodeResult.ok);
+    });
+  });
+
+  test('Decode type ambiguity resolution', () => {
+    const unionCodec = unionOfLiterals([1, '1', 2, '2', 3, '3']);
+    const decodeResult = unionCodec.decode('2');
+    assert(decodeResult.ok);
+    expect(decodeResult.data).toBe(2);
+  });
+
+  test('Invalid union', () => {
+    expect(() => {
+      // @ts-expect-error
+      unionOfLiterals([1, 2, { five: 'Three, sir' }]);
+    }).toThrowError();
+  });
+});

--- a/src/codecs/unionOfLiterals.ts
+++ b/src/codecs/unionOfLiterals.ts
@@ -1,0 +1,107 @@
+import { ValueCodec } from '../lib/types';
+import { error, ok, Result } from '../lib/result';
+import stringCodec from './stringCodec';
+import numberCodec from './numberCodec';
+
+export type SupportedLiteralType = string | number;
+
+const decodersByType = {
+  string: stringCodec.decode,
+  number: numberCodec.decode,
+};
+
+/**
+ * Encodes a union of literal values as a URI component and back again.
+ *
+ * **Note:** If `literalValues` contains both a number and its string
+ * form, precedence will be based on their order when decoding. For
+ * example, if `1, '1'` are passed in as the definition of the union and
+ * `decode()` is called with `'1'`, the result will be the number `1`
+ * because it was the first matching member of the union.
+ *
+ * @see stringCodec
+ * @see numberCodec
+ */
+const unionOfLiterals = <T extends SupportedLiteralType>(
+  literalValues: Array<T>
+): ValueCodec<T> => {
+  for (const literalValue of literalValues) {
+    if (!((typeof literalValue) in decodersByType)) {
+      throw new Error(
+        `Cannot create a codec for a union of literals containing a member of type ${typeof literalValue}`
+      );
+    }
+  }
+  return {
+    encode: (value, defaultValue) => {
+      if (value === defaultValue) {
+        return ok(undefined);
+      }
+      if (!literalValues.includes(value)) {
+        return error(
+          new Error(
+            `Cannot encode ${value} because it is not a member of the union of expected values`
+          )
+        );
+      }
+      if (typeof value === 'string') {
+        return stringCodec.encode(value);
+      }
+      if (typeof value === 'number') {
+        return numberCodec.encode(value);
+      }
+      return error(
+        new Error(
+          `Values of type ${typeof value} cannot be encoded as a member of a union of literals`
+        )
+      );
+    },
+    decode: (encodedValue, defaultValue) => {
+      if (encodedValue === undefined) {
+        return ok(defaultValue);
+      }
+
+      const decodeResultsByType = {
+        string: decodersByType.string(encodedValue),
+        number: decodersByType.number(encodedValue),
+      } as const satisfies Record<keyof typeof decodersByType, Result<unknown>>;
+
+      const errors: Error[] = [];
+
+      for (const literalValue of literalValues) {
+        // Runtime type checking was already done above in the outer
+        // factory function.
+        const literalValueType =
+          typeof literalValue as keyof typeof decodersByType;
+        const decodeResult = decodeResultsByType[literalValueType];
+        if (!decodeResult.ok) {
+          errors.push(
+            new Error(
+              `Encoded value "${encodedValue}" does not match the literal ${literalValueType} ${literalValue} union member because it could not be decoded as such`,
+              { cause: decodeResult.error }
+            )
+          );
+          continue;
+        }
+        if (decodeResult.data !== literalValue) {
+          errors.push(
+            new Error(
+              `Encoded value "${encodedValue}" does not match the literal ${literalValueType} ${literalValue} union member because its decoded value, ${decodeResult.data}, differs`
+            )
+          );
+          continue;
+        }
+        return ok(literalValue);
+      }
+
+      return error(
+        new Error(
+          `Unable to match encoded value ${encodedValue} to a member of its expected union`,
+          { cause: errors }
+        )
+      );
+    },
+  };
+};
+
+export default unionOfLiterals;

--- a/src/demo/2-nestedState.test.ts
+++ b/src/demo/2-nestedState.test.ts
@@ -8,6 +8,7 @@ import nullable from '../codecs/wrappers/nullable';
 import base64JsonCodec from '../codecs/base64JsonCodec';
 import withRfc6902JsonPatch from '../codecs/wrappers/withRfc6902JsonPatch';
 import withDeflateRaw from '../codecs/wrappers/withDeflateRaw';
+import unionOfLiterals from '../codecs/unionOfLiterals';
 
 /**
  * Now let's try something a little more complicated.
@@ -16,7 +17,7 @@ interface NestedMapState {
   mapControls: {
     center: [lat: number, lon: number];
     zoom: number;
-    projection: string;
+    projection: 'EPSG:3857' | 'EPSG:32661' | 'EPSG:32761';
   };
   dataParameters: {
     startDate: Date | null;
@@ -87,7 +88,12 @@ describe('Demo: nested state', () => {
 
   const mc = mapControls.connect('center', 'mc', arrayOf(numberCodec, 'x', 2));
   const mz = mapControls.connect('zoom', 'mz', numberCodec);
-  const mp = mapControls.connect('projection', 'mp', stringCodec);
+
+  const projectionCodec = unionOfLiterals<
+    NestedMapState['mapControls']['projection']
+  >(['EPSG:3857', 'EPSG:32661', 'EPSG:32761']);
+  const mp = mapControls.connect('projection', 'mp', projectionCodec);
+
   const ds = dataParameters.connect('startDate', 'ds', nullableDateCodec);
   const de = dataParameters.connect('endDate', 'de', nullableDateCodec);
   const mls = root.connect('mapLayers', 'mls', compressedDiffCodec);


### PR DESCRIPTION
@paumoreno, this is a [show](https://martinfowler.com/articles/ship-show-ask.html) PR for a new feature. After linking locally to our latest project and doing some rudimentary integration testing, I’m confident it will work as expected.

The basic idea is that it should be easy to create a codec for a parameter for which only specific values (which can be defined in TypeScript as a union of string and/or number literals) are allowed. `unionOfLiterals` is born of this necessity.

See updates to `src/demo/2-nestedState.test.ts` for a practical example of how to use it.